### PR TITLE
Add debugging context

### DIFF
--- a/src/DebuggingContext.php
+++ b/src/DebuggingContext.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Frontkom\CommonBehatDefinitions;
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Class Debugging.
+ *
+ * Provide Behat step-definitions for actions helpful when debugging.
+ */
+class DebuggingContext extends RawDrupalContext {
+
+  /**
+   * Defines if logs should be deleted after each scenario.
+   *
+   * @var string
+   */
+  protected $deleteLogsPerScenario;
+
+  /**
+   * DebuggingContext constructor.
+   */
+  public function __construct($deleteLogsPerScenario = FALSE) {
+    $this->deleteLogsPerScenario = $deleteLogsPerScenario;
+  }
+
+  /**
+   * Prints from watchdog at failed step.
+   *
+   * @AfterStep
+   */
+  public function logDumpAfterStep(AfterStepScope $scope) {
+    $failed = (99 === $scope->getTestResult()->getResultCode());
+    $database = \Drupal::database();
+
+    if ($failed && $database->schema()->tableExists('watchdog')) {
+      $query = $database->select('watchdog', 'w');
+
+      $query
+        ->range(0, 30)
+        ->fields('w')
+        ->orderBy('wid', 'DESC');
+      $rsc = $query->execute();
+      $table = [];
+      while ($result = $rsc->fetchObject()) {
+        $table[$result->wid] = (array) $result;
+      }
+      print_r($table);
+    }
+  }
+
+  /**
+   * Deletes from watchdog the logs that won't be related to the next scenario.
+   *
+   * @AfterScenario
+   */
+  public function deleteLogs() {
+    if (!$this->deleteLogsPerScenario) {
+      return;
+    }
+
+    $query = \Drupal::database()
+      ->delete('watchdog');
+
+    $query->execute();
+  }
+
+}

--- a/src/DebuggingContext.php
+++ b/src/DebuggingContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Frontkom\CommonBehatDefinitions;
+namespace Frontkom\DrupalBehatDefinitions;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Drupal\DrupalExtension\Context\RawDrupalContext;


### PR DESCRIPTION
**References** <!-- Link to the Jira task -->

### Changed <!-- What changed with this PR -->
This context provides 2 things:
- New way of dumping the logs after failed step - I cannot find a thread, but the previous step definition was somehow problematic after upgrade to D10 so we decided to implement the new way
- Deleting the logs after scenario - The most benefit from it is that if a scenario fails you see logs related only to that one scenario, so the old logs won't be misleading and the output is more clear

### Visuals <!-- Add here some screenshots -->
None

### How can this be validated? <!-- Instructions for QA -->
1. Use the DebuggingContext in behat config file
2. Prepare a test using some of these steps
3. Run behat tests

### Pull request checklist
- [x] Can be deploy automatically? _If manual actions are required:_ did you describe the deploy steps?
- [x] Is the documentation updated, if it makes sense? <!-- Check this also if no updating is needed -->
- [x] Are necessary translations added/updated? <!-- Check this even if no translations are being changed -->
- [x] Did you update sanitization routines, where personal information is handled?
